### PR TITLE
Feat domain specific forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A high-performance, cache-enabled DNS forwarder written in Go. This project forw
 ## Features
 - **DNS Forwarding:** Forwards DNS queries to one or more upstream DNS servers.
 - **Client-Based Routing:** Route different clients to different upstream DNS servers (private/public).
+- **Domain Routing:** Forward DNS queries for specific domains to designated upstream servers.
 - **Caching:** Uses an in-memory cache to store DNS responses, reducing latency and upstream load.
 - **Health Checks:** Periodically checks upstream DNS server reachability and only uses healthy servers.
 - **Statistics:** Logs DNS usage and cache hit/miss rates.
@@ -80,6 +81,10 @@ ENABLE_CLIENT_ROUTING=true
 PRIVATE_DNS_SERVERS=192.168.1.1:53,192.168.1.2:53
 PUBLIC_DNS_SERVERS=1.1.1.1:53,8.8.8.8:53
 PUBLIC_ONLY_CLIENTS=192.168.1.100,10.0.0.50
+
+# Domain Routing (Optional)
+ENABLE_DOMAIN_ROUTING=true
+DOMAIN_ROUTING_FILES=/etc/dnsforwarder/domain-routes.txt,/etc/dnsforwarder/extra-routes.txt
 ```
 
 #### Basic Configuration
@@ -100,6 +105,10 @@ PUBLIC_ONLY_CLIENTS=192.168.1.100,10.0.0.50
 - **PRIVATE_DNS_SERVERS:** Comma-separated list of private DNS servers (e.g., PiHole, AdGuard Home).
 - **PUBLIC_DNS_SERVERS:** Comma-separated list of public DNS servers (e.g., Cloudflare, Google).
 - **PUBLIC_ONLY_CLIENTS:** Comma-separated list of client IPs that should only use public DNS servers.
+
+#### Domain Routing Configuration
+- **ENABLE_DOMAIN_ROUTING:** Enable domain routing (default `false`).
+- **DOMAIN_ROUTING_FILES:** Comma-separated list of files containing domain routing rules.
 
 ### 5. Client-Based DNS Routing
 
@@ -171,6 +180,49 @@ PUBLIC_ONLY_CLIENT_MACS=11:22:33:44:55:66           # Guest device (by MAC)
 - **Reliability:** Automatic fallback ensures DNS always works
 - **Performance:** Private servers first, public as backup
 - **Monitoring:** All DNS routing decisions are logged and can be monitored via Prometheus metrics
+
+## Domain Routing
+
+Domain routing allows you to forward DNS queries for specific domains to specific upstream DNS servers. This is useful for scenarios such as:
+- Sending queries for internal domains to a private DNS server
+- Forwarding queries for certain public domains to a specific provider
+- Overriding DNS for selected domains
+
+### How It Works
+- When `ENABLE_DOMAIN_ROUTING=true` is set, the DNS forwarder loads domain routing rules from one or more configuration files specified in the `DOMAIN_ROUTING_FILES` environment variable.
+- Each file should contain rules in the format: `/domain/ip`, one per line. Lines starting with `#` are treated as comments.
+- When a DNS query matches a domain in the routing table, the query is forwarded to the specified IP address for that domain.
+- If no match is found, normal client or default routing is used.
+
+### Example Configuration
+Add to your `.env` file:
+```
+ENABLE_DOMAIN_ROUTING=true
+DOMAIN_ROUTING_FILES=/etc/dnsforwarder/domain-routes.txt,/etc/dnsforwarder/extra-routes.txt
+```
+
+Example `domain-routes.txt`:
+```
+# Format: /domain/ip
+address=/example.com/192.168.1.10
+address=/internal.corp/10.10.1.1
+# You can add as many rules as needed
+```
+
+### Notes
+- The domain routing file must be a plain text file, not a directory.
+- Routing file follows dnsmasq conventions of domain routing for easier integration with existing tools.
+- Each rule must have both a domain and an IP address, separated by `/`.
+- The routing table is loaded at startup and logged for diagnostics.
+- If no domain routing files are specified, domain routing will not be enabled.
+- If a domain is not found in the routing table, the forwarder falls back to client or default routing.
+
+### Troubleshooting
+- Check logs for messages about domain routing initialization and file loading errors.
+- Make sure the file paths in `DOMAIN_ROUTING_FILES` are correct and accessible by the DNS forwarder.
+- Ensure each rule is in the correct format and not commented out.
+
+---
 
 ### 6. Logging & Stats
 - Logs are written to stdout and kept in a ring buffer for diagnostics.

--- a/README.md
+++ b/README.md
@@ -273,3 +273,36 @@ GNU General Public License v3.0
 ## Credits
 - [miekg/dns](https://github.com/miekg/dns)
 - [patrickmn/go-cache](https://github.com/patrickmn/go-cache)
+
+### Example: Docker Compose with Domain Routing
+
+Here is a sample `docker-compose.yml` for running DNS Forwarder with domain routing support:
+
+```yaml
+docker-compose.yml
+------------------
+services:
+  app:
+    build:
+      context: .
+      args:
+        TARGETOS: linux
+        TARGETARCH: amd64
+    ports:
+      - "53:53/udp"
+      - "8080:8080" # Optional: Expose metrics on port 8080
+    env_file:
+      - .env
+    restart: always
+    environment:
+      - TZ=Asia/Kolkata
+    volumes:
+      - ./domain-routes.txt:/etc/dnsforwarder/domain-routes.txt:ro
+      # Add more files as needed
+```
+
+- Place your domain routing rules in `domain-routes.txt` in the project root.
+- The file will be available inside the container at `/etc/dnsforwarder/domain-routes.txt`.
+- Update your `.env` file to reference the correct path for `DOMAIN_ROUTING_FILES`.
+
+This setup ensures your custom domain routing configuration is available to the DNS forwarder running in Docker.

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -159,15 +159,15 @@ func StartCacheStatsLogger() {
 			if requests > 0 {
 				hitPct = (float64(hits) / float64(requests)) * 100
 			}
-			logutil.LogWithBufferf("[CACHE STATS] Requests: %d, Hits: %d, Hit Rate: %.2f%%, Miss Rate: %.2f%%",
+			logutil.LogWithBufferf("Requests: %d, Hits: %d, Hit Rate: %.2f%%, Miss Rate: %.2f%%",
 				requests, hits, hitPct, 100-hitPct)
 			if DnsCache != nil {
 				items := DnsCache.Items()
 				itemCount := len(items)
 				if itemCount == 0 {
-					logutil.LogWithBufferf("[CACHE STATS] No cache entries found")
+					logutil.LogWithBufferf("No cache entries found")
 				} else {
-					logutil.LogWithBufferf("[CACHE STATS] Cache Entries: %d", itemCount)
+					logutil.LogWithBufferf("Cache Entries: %d", itemCount)
 					if EnableMetrics {
 						metric.MetricsRecorderInstance.UpdateCacheSize(itemCount)
 					}

--- a/clientrouting/clientrouting.go
+++ b/clientrouting/clientrouting.go
@@ -23,6 +23,7 @@ func InitializeClientRouting() {
 	if !config.EnableClientRouting {
 		return
 	}
+	logutil.LogWithBufferf("Client-based DNS routing enabled")
 
 	PrivateServersSet = make(map[string]struct{})
 	PublicServersSet = make(map[string]struct{})
@@ -56,7 +57,6 @@ func InitializeClientRouting() {
 
 	logutil.LogWithBufferf("Private servers: %v", config.PrivateServers)
 	logutil.LogWithBufferf("Public servers: %v", config.PublicServers)
-	logutil.LogWithBufferf("Client routing enabled: %v", config.EnableClientRouting)
 }
 
 func ShouldUsePublicServers(clientIP string) bool {

--- a/clientrouting/clientrouting.go
+++ b/clientrouting/clientrouting.go
@@ -43,20 +43,20 @@ func InitializeClientRouting() {
 	for _, client := range config.PublicOnlyClients {
 		if client != "" {
 			PublicOnlyClientsMap.Store(strings.TrimSpace(client), true)
-			logutil.LogWithBufferf("[CLIENT-ROUTING] Configured client %s to use public servers only (IP)", client)
+			logutil.LogWithBufferf("Configured client %s to use public servers only (IP)", client)
 		}
 	}
 	for _, mac := range config.PublicOnlyClientMACs {
 		macNorm := util.NormalizeMAC(mac)
 		if macNorm != "" {
 			PublicOnlyClientMACsMap.Store(macNorm, true)
-			logutil.LogWithBufferf("[CLIENT-ROUTING] Configured client %s to use public servers only (MAC)", macNorm)
+			logutil.LogWithBufferf("Configured client %s to use public servers only (MAC)", macNorm)
 		}
 	}
 
-	logutil.LogWithBufferf("[CLIENT-ROUTING] Private servers: %v", config.PrivateServers)
-	logutil.LogWithBufferf("[CLIENT-ROUTING] Public servers: %v", config.PublicServers)
-	logutil.LogWithBufferf("[CLIENT-ROUTING] Client routing enabled: %v", config.EnableClientRouting)
+	logutil.LogWithBufferf("Private servers: %v", config.PrivateServers)
+	logutil.LogWithBufferf("Public servers: %v", config.PublicServers)
+	logutil.LogWithBufferf("Client routing enabled: %v", config.EnableClientRouting)
 }
 
 func ShouldUsePublicServers(clientIP string) bool {

--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,8 @@ var (
 	DefaultDNSServer   = util.GetEnvString("DEFAULT_DNS_SERVER", "8.8.8.8:53")
 	DefaultCacheSize   = util.GetEnvInt("CACHE_SIZE", 10000)
 	DefaultDNSCacheTTL = util.GetEnvDuration("DNS_CACHE_TTL", 30*time.Minute)
+
+	// Metrics configuration
 	DefaultMetricsPort = util.GetEnvString("METRICS_PORT", ":8080")
 	EnableMetrics      = util.GetEnvBool("ENABLE_METRICS", true)
 

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,12 @@ import (
 	"time"
 )
 
+const ARecordInvalidAnswer = "0.0.0.0"
+const AAAARecordInvalidAnswer = "::"
+const NegativeResponseTTLDivisor = 4
+const MinCacheTTL = 30 * time.Second
+const MaxCacheTTL = 24 * time.Hour
+
 var (
 	DefaultCacheTTL    = util.GetEnvDuration("CACHE_TTL", 10*time.Second)
 	DefaultDNSTimeout  = util.GetEnvDuration("DNS_TIMEOUT", 5*time.Second)
@@ -27,4 +33,8 @@ var (
 	PublicOnlyClients    = util.GetEnvStringSlice("PUBLIC_ONLY_CLIENTS", "")
 	PublicOnlyClientMACs = util.GetEnvStringSlice("PUBLIC_ONLY_CLIENT_MACS", "")
 	EnableClientRouting  = util.GetEnvBool("ENABLE_CLIENT_ROUTING", false)
+
+	// Domain routing configuration
+	EnableDomainRouting = util.GetEnvBool("ENABLE_DOMAIN_ROUTING", false)
+	DomainRoutingFiles  = util.GetEnvStringSlice("DOMAIN_ROUTING_FILES", "")
 )

--- a/dnsresolver/dnsresolver.go
+++ b/dnsresolver/dnsresolver.go
@@ -96,7 +96,6 @@ func upstreamDNSQuery(servers []string, m *dns.Msg) []dns.RR {
 			statsMutex.Lock()
 			dnsUsageStats[svr]++
 			statsMutex.Unlock()
-
 			if config.EnableMetrics {
 				metricsRecorder.RecordUpstreamQuery(svr, "success", rtt)
 			}

--- a/dnsresolver/dnsresolver.go
+++ b/dnsresolver/dnsresolver.go
@@ -1,0 +1,112 @@
+package dnsresolver
+
+import (
+	"dnsloadbalancer/clientrouting"
+	"dnsloadbalancer/config"
+	"dnsloadbalancer/dnssource"
+	"dnsloadbalancer/domainrouting"
+	"dnsloadbalancer/logutil"
+
+	"sync"
+	"time"
+
+	"dnsloadbalancer/metric"
+
+	"github.com/miekg/dns"
+)
+
+var (
+	metricsRecorder = metric.MetricsRecorderInstance
+	dnsUsageStats   = make(map[string]int)
+	statsMutex      sync.Mutex
+	cacheTTL        = config.DefaultCacheTTL
+	dnsClient       = &dns.Client{Timeout: config.DefaultDNSTimeout}
+	dnsMsgPool      = sync.Pool{New: func() interface{} { return new(dns.Msg) }}
+)
+
+func UpdateDNSServersCache() {
+	dnssource.UpdateDNSServersCache(
+		metric.MetricsRecorderInstance,
+		cacheTTL,
+		config.EnableClientRouting,
+		config.PrivateServers,
+		config.PublicServers,
+		dnsClient,
+		&dnsMsgPool,
+	)
+}
+
+func getCachedDNSServers() []string {
+	var servers []string
+	dnssource.CacheMutex.RLock()
+	cacheValid := time.Since(dnssource.CacheLastUpdated) <= cacheTTL && len(dnssource.ReachableServersCache) > 0
+	servers = append([]string(nil), dnssource.ReachableServersCache...)
+	dnssource.CacheMutex.RUnlock()
+
+	if cacheValid {
+		return servers
+	}
+	UpdateDNSServersCache()
+	dnssource.CacheMutex.RLock()
+	servers = append([]string(nil), dnssource.ReachableServersCache...)
+	dnssource.CacheMutex.RUnlock()
+	return servers
+}
+
+func ResolverForClient(domain string, qtype uint16, clientIP string) []dns.RR {
+	m := dnsMsgPool.Get().(*dns.Msg)
+	defer dnsMsgPool.Put(m)
+	m.SetQuestion(dns.Fqdn(domain), qtype)
+	m.RecursionDesired = true
+	var servers []string
+	// Prefer client-specific servers if clientIP is available
+	// This allows client routing to take precedence over the general server cache.
+	// If client routing is not enabled or no specific servers are found, fallback to cached servers
+	// or default servers.
+	if clientIP != "" {
+		servers = clientrouting.GetServersForClient(clientIP, &dnssource.CacheMutex)
+		if servers == nil {
+			servers = getCachedDNSServers()
+		}
+	} else {
+		servers = getCachedDNSServers()
+	}
+	return upstreamDNSQuery(servers, m)
+}
+
+func ResolverForDomain(domain string, qtype uint16, clientIP string) []dns.RR {
+	m := dnsMsgPool.Get().(*dns.Msg)
+	defer dnsMsgPool.Put(m)
+	m.SetQuestion(dns.Fqdn(domain), qtype)
+	m.RecursionDesired = true
+	if svr, ok := domainrouting.RoutingTable[domain]; ok {
+		return upstreamDNSQuery([]string{svr}, m)
+	}
+	return ResolverForClient(domain, qtype, clientIP)
+}
+
+func upstreamDNSQuery(servers []string, m *dns.Msg) []dns.RR {
+	if len(servers) == 0 {
+		logutil.LogWithBufferf("[ERROR] No upstream DNS servers available")
+		return nil
+	}
+	for _, svr := range servers {
+		response, rtt, err := dnsClient.Exchange(m, svr)
+		if err == nil && response != nil {
+			statsMutex.Lock()
+			dnsUsageStats[svr]++
+			statsMutex.Unlock()
+
+			if config.EnableMetrics {
+				metricsRecorder.RecordUpstreamQuery(svr, "success", rtt)
+			}
+			return response.Answer
+		}
+		logutil.LogWithBufferf("[WARNING] exchange error using server %s: %v", svr, err)
+		if config.EnableMetrics {
+			metricsRecorder.RecordUpstreamQuery(svr, "error", rtt)
+			metricsRecorder.RecordError("upstream_query_failed", "dns_exchange")
+		}
+	}
+	return nil
+}

--- a/dnssource/dnssource.go
+++ b/dnssource/dnssource.go
@@ -22,12 +22,14 @@ var (
 	CacheMutex            sync.RWMutex
 )
 
-func UpdateDNSServersCache(metricsRecorder interface {
+type metricsRecorderInterface interface {
 	RecordError(string, string)
 	SetUpstreamServersTotal(int)
 	SetUpstreamServerReachable(string, bool)
 	RecordUpstreamQuery(string, string, time.Duration)
-},
+}
+
+func UpdateDNSServersCache(metricsRecorder metricsRecorderInterface,
 	cacheTTL time.Duration,
 	clientRoutingEnabled bool,
 	privateServers, publicServers []string,
@@ -40,39 +42,47 @@ func UpdateDNSServersCache(metricsRecorder interface {
 		logutil.LogWithBufferFatalf("[ERROR] no DNS servers found")
 	}
 
-	if config.EnableMetrics {
-		metricsRecorder.SetUpstreamServersTotal(len(servers))
-	}
-
-	type result struct {
-		server string
-		ok     bool
-	}
-
-	allServersToTest := make([]string, 0)
-	allServersToTest = append(allServersToTest, servers...)
+	upstreamServerCount := len(servers)
 	if clientRoutingEnabled {
-		allServersToTest = append(allServersToTest, privateServers...)
-		allServersToTest = append(allServersToTest, publicServers...)
+		upstreamServerCount += len(privateServers) + len(publicServers)
 	}
 
-	serverSet := make(map[string]bool)
-	uniqueServers := make([]string, 0)
-	for _, server := range allServersToTest {
-		if server != "" && !serverSet[server] {
-			serverSet[server] = true
-			uniqueServers = append(uniqueServers, server)
+	if config.EnableMetrics {
+		metricsRecorder.SetUpstreamServersTotal(upstreamServerCount)
+	}
+
+	allServersToTest := make(map[string]bool)
+	for _, server := range servers {
+		if server != "" {
+			allServersToTest[server] = true
+		}
+	}
+	if clientRoutingEnabled {
+		for _, server := range privateServers {
+			if server != "" {
+				allServersToTest[server] = true
+			}
+		}
+		for _, server := range publicServers {
+			if server != "" {
+				allServersToTest[server] = true
+			}
 		}
 	}
 
-	m := dnsMsgPool.Get().(*dns.Msg)
-	defer dnsMsgPool.Put(m)
-	m.SetQuestion(config.DefaultTestDomain+".", dns.TypeA)
-	m.RecursionDesired = true
+	uniqueServers := make([]string, 0, len(allServersToTest))
+	for server := range allServersToTest {
+		uniqueServers = append(uniqueServers, server)
+	}
 
-	reachableCh := make(chan result, len(uniqueServers))
-	var wg sync.WaitGroup
-	sem := make(chan struct{}, config.DefaultWorkerCount)
+	var (
+		reachable        = make([]string, 0, len(uniqueServers))  // preallocate
+		reachablePrivate = make([]string, 0, len(privateServers)) // preallocate
+		reachablePublic  = make([]string, 0, len(publicServers))  // preallocate
+		mu               sync.Mutex
+		wg               sync.WaitGroup
+		sem              = make(chan struct{}, config.DefaultWorkerCount)
+	)
 
 	for _, server := range uniqueServers {
 		wg.Add(1)
@@ -81,47 +91,43 @@ func UpdateDNSServersCache(metricsRecorder interface {
 			defer wg.Done()
 			defer func() { <-sem }()
 
-			start := time.Now()
-			_, _, err := dnsClient.Exchange(m.Copy(), svr)
-			duration := time.Since(start)
+			m := dnsMsgPool.Get().(*dns.Msg)
+			m.SetQuestion(config.DefaultTestDomain+".", dns.TypeA)
+			m.RecursionDesired = true
+
+			_, rtt, err := dnsClient.Exchange(m, svr)
+			dnsMsgPool.Put(m) // immediately return to pool
 
 			if err != nil {
 				logutil.LogWithBufferf("[WARNING] server %s is not reachable: %v", svr, err)
 				if config.EnableMetrics {
 					metricsRecorder.SetUpstreamServerReachable(svr, false)
-					metricsRecorder.RecordUpstreamQuery(svr, "error", duration)
+					metricsRecorder.RecordUpstreamQuery(svr, "error", rtt)
 					metricsRecorder.RecordError("upstream_unreachable", "health_check")
 				}
-				reachableCh <- result{server: svr, ok: false}
 				return
 			}
 
 			if config.EnableMetrics {
 				metricsRecorder.SetUpstreamServerReachable(svr, true)
-				metricsRecorder.RecordUpstreamQuery(svr, "success", duration)
+				metricsRecorder.RecordUpstreamQuery(svr, "success", rtt)
 			}
-			reachableCh <- result{server: svr, ok: true}
+
+			mu.Lock()
+			reachable = append(reachable, svr)
+			if clientRoutingEnabled {
+				if clientrouting.IsPrivateServer(svr) {
+					reachablePrivate = append(reachablePrivate, svr)
+				} else if clientrouting.IsPublicServer(svr) {
+					reachablePublic = append(reachablePublic, svr)
+				}
+			}
+			mu.Unlock()
 		}(server)
 	}
 
 	wg.Wait()
-	close(reachableCh)
-	var reachable []string
-	var reachablePrivate []string
-	var reachablePublic []string
-
-	for res := range reachableCh {
-		if res.ok {
-			reachable = append(reachable, res.server)
-			if clientRoutingEnabled {
-				if clientrouting.IsPrivateServer(res.server) {
-					reachablePrivate = append(reachablePrivate, res.server)
-				} else if clientrouting.IsPublicServer(res.server) {
-					reachablePublic = append(reachablePublic, res.server)
-				}
-			}
-		}
-	}
+	close(sem)
 
 	if len(reachable) == 0 {
 		if config.EnableMetrics {

--- a/dnssource/dnssource.go
+++ b/dnssource/dnssource.go
@@ -127,7 +127,6 @@ func UpdateDNSServersCache(metricsRecorder metricsRecorderInterface,
 	}
 
 	wg.Wait()
-	close(sem)
 
 	if len(reachable) == 0 {
 		if config.EnableMetrics {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,3 +13,6 @@ services:
     restart: always
     environment:
       - TZ=Asia/Kolkata
+    volumes: # optional required for custom domain routes
+      - ./domain-routes.txt:/etc/dnsforwarder/domain-routes.txt:ro
+      # Add more files as needed

--- a/domainrouting/domainrouting.go
+++ b/domainrouting/domainrouting.go
@@ -1,0 +1,95 @@
+package domainrouting
+
+import (
+	"dnsloadbalancer/config"
+	"dnsloadbalancer/logutil"
+	"os"
+	"strings"
+	"sync"
+)
+
+var RoutingTable = make(map[string]string)
+
+func InitializeDomainRouting() {
+	if !config.EnableDomainRouting {
+		return
+	}
+	// domain routing logic
+	if len(config.DomainRoutingFiles) == 0 {
+		logutil.LogWithBufferf("Domain routing is enabled but no configuration files are specified")
+		os.Exit(1)
+	}
+	logutil.LogWithBufferf("Domain routing enabled with files: %v", config.DomainRoutingFiles)
+	loadRoutingTable(config.DomainRoutingFiles)
+	logutil.LogWithBufferf("Domain routing initialized successfully")
+	logutil.LogWithBufferf("Routing table size: %d", len(RoutingTable))
+}
+
+// splitCharacter splits a string into substrings based on a delimiter.
+func splitCharacter(s string, character string) []string {
+	var substrings []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if string(s[i]) == character {
+			substrings = append(substrings, s[start:i])
+			start = i + 1
+		}
+	}
+	substrings = append(substrings, s[start:])
+	return substrings
+}
+
+func loadRoutingTable(files []string) {
+	var wg sync.WaitGroup
+	var mu sync.Mutex
+
+	for _, file := range files {
+		wg.Add(1)
+		go func(file string) {
+			defer wg.Done()
+			fileInfo, err := os.Stat(file)
+			if err != nil {
+				logutil.LogWithBufferf("Domain routing file %s error: %v", file, err)
+				os.Exit(1)
+			}
+			if fileInfo.IsDir() {
+				logutil.LogWithBufferf("Domain routing file %s is a directory", file)
+				os.Exit(1)
+			}
+			logutil.LogWithBufferf("Loading domain routing configuration from %s", file)
+			fileContent, err := os.ReadFile(file)
+			if err != nil {
+				logutil.LogWithBufferf("Error reading domain routing file %s: %v", file, err)
+				os.Exit(1)
+			}
+			lines := splitCharacter(string(fileContent), "\n")
+			for _, line := range lines {
+				line = strings.TrimSpace(line)
+				if line == "" || line[0] == '#' {
+					continue
+				}
+				parts := splitCharacter(line, "/")
+				if len(parts) < 3 {
+					continue
+				}
+				domain, ip := parts[1], parts[2]
+				if domain == "" || ip == "" {
+					continue
+				}
+				// add '.' to domain at end if not present
+				if !strings.HasSuffix(domain, ".") {
+					domain += "."
+				}
+				// add ':53' to IP end if not present to ensure it's a valid DNS server address
+				if !strings.HasSuffix(ip, ":53") {
+					logutil.LogWithBufferf("[DEBUG] Adding port 53 to IP %s for domain %s", ip, domain)
+					ip += ":53"
+				}
+				mu.Lock()
+				RoutingTable[domain] = ip
+				mu.Unlock()
+			}
+		}(file)
+	}
+	wg.Wait()
+}

--- a/domainrouting/domainrouting.go
+++ b/domainrouting/domainrouting.go
@@ -25,20 +25,6 @@ func InitializeDomainRouting() {
 	logutil.LogWithBufferf("Routing table size: %d", len(RoutingTable))
 }
 
-// splitCharacter splits a string into substrings based on a delimiter.
-func splitCharacter(s string, character string) []string {
-	var substrings []string
-	start := 0
-	for i := 0; i < len(s); i++ {
-		if string(s[i]) == character {
-			substrings = append(substrings, s[start:i])
-			start = i + 1
-		}
-	}
-	substrings = append(substrings, s[start:])
-	return substrings
-}
-
 func loadRoutingTable(files []string) {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
@@ -62,13 +48,13 @@ func loadRoutingTable(files []string) {
 				logutil.LogWithBufferf("Error reading domain routing file %s: %v", file, err)
 				os.Exit(1)
 			}
-			lines := splitCharacter(string(fileContent), "\n")
+			lines := strings.Split(string(fileContent), "\n")
 			for _, line := range lines {
 				line = strings.TrimSpace(line)
-				if line == "" || line[0] == '#' {
+				if line != "" && line[0] == '#' {
 					continue
 				}
-				parts := splitCharacter(line, "/")
+				parts := strings.Split(line, "/")
 				if len(parts) < 3 {
 					continue
 				}

--- a/logutil/logutil.go
+++ b/logutil/logutil.go
@@ -6,6 +6,10 @@ import (
 	"sync"
 )
 
+func init() {
+	log.SetFlags(log.Ldate | log.Ltime | log.Lshortfile)
+}
+
 type LogRingBuffer struct {
 	entries []string
 	max     int

--- a/main.go
+++ b/main.go
@@ -5,119 +5,18 @@ import (
 	"dnsloadbalancer/cache"
 	"dnsloadbalancer/clientrouting"
 	"dnsloadbalancer/config"
-	"dnsloadbalancer/dnssource"
+	"dnsloadbalancer/dnsresolver"
+	"dnsloadbalancer/domainrouting"
 	"dnsloadbalancer/logutil"
 	"dnsloadbalancer/util"
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
 	"time"
 
 	"github.com/miekg/dns"
 )
 
-var (
-	dnsUsageStats = make(map[string]int)
-	statsMutex    sync.Mutex
-
-	cacheTTL   = config.DefaultCacheTTL
-	dnsClient  = &dns.Client{Timeout: config.DefaultDNSTimeout}
-	dnsMsgPool = sync.Pool{New: func() interface{} { return new(dns.Msg) }}
-)
-
-// --- DNS Resolver ---
-func resolver(domain string, qtype uint16) []dns.RR {
-	return resolverForClient(domain, qtype, "")
-}
-
-func resolverForClient(domain string, qtype uint16, clientIP string) []dns.RR {
-	m := dnsMsgPool.Get().(*dns.Msg)
-	defer dnsMsgPool.Put(m)
-	m.SetQuestion(dns.Fqdn(domain), qtype)
-	m.RecursionDesired = true
-
-	var servers []string
-	// Prefer client-specific servers if clientIP is available
-	// This allows client routing to take precedence over the general server cache.
-	// If client routing is not enabled or no specific servers are found, fallback to cached servers
-	// or default servers.
-	if config.EnableClientRouting && clientIP != "" {
-		servers = clientrouting.GetServersForClient(clientIP, &dnssource.CacheMutex)
-		if servers == nil {
-			servers = getCachedDNSServers()
-		}
-	} else {
-		servers = getCachedDNSServers()
-	}
-
-	var response *dns.Msg
-	var err error
-
-	for _, svr := range servers {
-		start := time.Now()
-		response, _, err = dnsClient.Exchange(m, svr)
-		duration := time.Since(start)
-
-		if err == nil && response != nil {
-			statsMutex.Lock()
-			dnsUsageStats[svr]++
-			statsMutex.Unlock()
-
-			if config.EnableMetrics {
-				metricsRecorder.RecordUpstreamQuery(svr, "success", duration)
-			}
-			return response.Answer
-		}
-
-		logutil.LogWithBufferf("[WARNING] exchange error using server %s: %v", svr, err)
-		if config.EnableMetrics {
-			metricsRecorder.RecordUpstreamQuery(svr, "error", duration)
-			metricsRecorder.RecordError("upstream_query_failed", "dns_exchange")
-		}
-	}
-
-	if config.EnableMetrics {
-		metricsRecorder.RecordError("all_upstream_failed", "dns_resolution")
-	}
-	logutil.LogWithBufferFatalf("[ERROR] all DNS exchanges failed")
-	return nil
-}
-
-func updateDNSServersCache() {
-	dnssource.UpdateDNSServersCache(
-		metricsRecorder,
-		cacheTTL,
-		config.EnableClientRouting,
-		config.PrivateServers,
-		config.PublicServers,
-		dnsClient,
-		&dnsMsgPool,
-	)
-}
-
-func getCachedDNSServers() []string {
-	dnssource.CacheMutex.RLock()
-	servers := make([]string, len(dnssource.ReachableServersCache))
-	copy(servers, dnssource.ReachableServersCache)
-	cacheValid := time.Since(dnssource.CacheLastUpdated) <= cacheTTL && len(servers) > 0
-	dnssource.CacheMutex.RUnlock()
-
-	if cacheValid {
-		return servers
-	}
-
-	// Update cache and try again
-	updateDNSServersCache()
-
-	dnssource.CacheMutex.RLock()
-	servers = make([]string, len(dnssource.ReachableServersCache))
-	copy(servers, dnssource.ReachableServersCache)
-	dnssource.CacheMutex.RUnlock()
-	return servers
-}
-
-// --- DNS Resolver ---
 type dnsHandler struct{}
 
 func (h *dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
@@ -129,8 +28,7 @@ func (h *dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 		q := r.Question[0]
 		clientIP := util.GetClientIP(w)
 		answers := cache.ResolverWithCache(
-			q.Name, q.Qtype,
-			resolver, resolverForClient, clientIP,
+			q.Name, q.Qtype, clientIP,
 		)
 		if answers != nil {
 			msg.Answer = answers
@@ -148,10 +46,11 @@ func (h *dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 // --- Server Startup ---
 func StartDNSServer() {
 	// --- Initialization ---
-	cache.Init(config.DefaultDNSCacheTTL, config.EnableMetrics, metricsRecorder, config.EnableClientRouting)
+	cache.Init(config.DefaultDNSCacheTTL, config.EnableMetrics, metricsRecorder, config.EnableClientRouting, config.EnableDomainRouting)
+	// this is blocking since all available upstream cache should be populated before starting server
+	dnsresolver.UpdateDNSServersCache()
+	domainrouting.InitializeDomainRouting()
 	clientrouting.InitializeClientRouting()
-	updateDNSServersCache()
-
 	// Start cache stats and metrics logging in background
 	go cache.StartCacheStatsLogger()
 	if config.EnableMetrics {
@@ -171,9 +70,6 @@ func StartDNSServer() {
 	}
 
 	logutil.LogWithBufferf("Starting DNS server on port 53 (UDP)")
-	if config.EnableClientRouting {
-		logutil.LogWithBufferf("Client-based DNS routing enabled")
-	}
 	// --- Server Execution ---
 	errCh := make(chan error, 1)
 	go func() {


### PR DESCRIPTION
Domain routing allows you to forward DNS queries for specific domains to specific upstream DNS servers. This is useful for scenarios such as:
- Sending queries for internal domains to a private DNS server
- Forwarding queries for certain public domains to a specific provider
- Overriding DNS for selected domains

### How It Works
- When `ENABLE_DOMAIN_ROUTING=true` is set, the DNS forwarder loads domain routing rules from one or more configuration files specified in the `DOMAIN_ROUTING_FILES` environment variable.
- Each file should contain rules in the format: `/domain/ip`, one per line. Lines starting with `#` are treated as comments.
- When a DNS query matches a domain in the routing table, the query is forwarded to the specified IP address for that domain.
- If no match is found, normal client or default routing is used.

### Example Configuration
Add to your `.env` file:
```
ENABLE_DOMAIN_ROUTING=true
DOMAIN_ROUTING_FILES=/etc/dnsforwarder/domain-routes.txt,/etc/dnsforwarder/extra-routes.txt
```

Example `domain-routes.txt`:
```
# Format: /domain/ip
address=/example.com/192.168.1.10
address=/internal.corp/10.10.1.1
# You can add as many rules as needed
```